### PR TITLE
Potential fix for code scanning alert no. 3: Missing regular expression anchor

### DIFF
--- a/assets/vendor/glightbox/js/glightbox.js
+++ b/assets/vendor/glightbox/js/glightbox.js
@@ -1967,7 +1967,7 @@
           return 'video';
         }
 
-        if (url.match(/vimeo\.com\/([0-9]*)/)) {
+        if (url.match(/^https?:\/\/vimeo\.com\/([0-9]+)$/)) {
           return 'video';
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/brooklynhelpdesk/bkhd.nyc/security/code-scanning/3](https://github.com/brooklynhelpdesk/bkhd.nyc/security/code-scanning/3)

To fix the problem, we need to add anchors to the regular expression to ensure it matches the expected part of the URL. Specifically, we should add the `^` anchor at the beginning to match the start of the string and the `$` anchor at the end to match the end of the string. This will ensure that the regular expression only matches URLs that exactly match the pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
